### PR TITLE
Fix last 3 bytes being hashed in the wrong order

### DIFF
--- a/src/main/java/hasher/Murmur2.java
+++ b/src/main/java/hasher/Murmur2.java
@@ -73,13 +73,13 @@ public class Murmur2 {
     int left = length - len_m;
     if (left != 0) {
       if (left >= 3) {
-        h ^= (int) data[length - 3] << 16;
+        h ^= (int) data[length - (left - 2)] << 16;
       }
       if (left >= 2) {
-        h ^= (int) data[length - 2] << 8;
+        h ^= (int) data[length - (left - 1)] << 8;
       }
       if (left >= 1) {
-        h ^= (int) data[length - 1];
+        h ^= (int) data[length - left];
       }
 
       h *= M_32;


### PR DESCRIPTION
In the [reference implementation](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp#L72), the last 3 bytes (when they exist) are mixed in the order of [last] then [last - 1] then [last - 2]. In this implementation, they are mixed in the order of [last - 2] then [last - 1] then [last]. This causes the results returned by each implementation to differ on some files.

This PR changes the order to the same as the reference implementation, so the hash returned is correct.